### PR TITLE
feat(datastore): fetch nested models - combine queries

### DIFF
--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
@@ -268,12 +268,11 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
                 nestedModelName,
                 queryOptions,
                 {
-                    val nestedModelList = it.toMutableList()
-                    val nestedModelHashMap = nestedModelList.associateBy({ nestedModel -> nestedModel.id }, { nestedModel -> nestedModel })
+                    val nestedModelHashMap = it.associateBy({ nestedModel -> nestedModel.id }, { nestedModel -> nestedModel })
                     val nestedFlutterSerializedModels = mutableListOf<FlutterSerializedModel>()
                     for (flutterSerializedModel in flutterSerializedModels) {
                         val nestedSerializedModel = flutterSerializedModel.serializedModel.serializedData[associationKey] as SerializedModel
-                        val modelId = nestedSerializedModel.serializedData["id"].toString();
+                        val modelId = nestedSerializedModel.serializedData["id"].toString()
                         val nestedModel = nestedModelHashMap[modelId]
                         if (nestedModel != null) {
                             val nestedFlutterSerializedModel = FlutterSerializedModel(nestedModel as SerializedModel)
@@ -302,7 +301,7 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
             queryOptionsList: List<QueryOptions>,
             onQueryResults: (result: List<Model>) -> Unit,
             onFailure: (e: DataStoreException) -> Unit,
-            previousResults: List<Model> = listOf<Model>()
+            previousResults: List<Model> = listOf()
     ) {
         val results = previousResults.toMutableList()
         if (queryOptionsList.isEmpty()) {

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/AmplifyDataStorePlugin.kt
@@ -274,19 +274,14 @@ class AmplifyDataStorePlugin : FlutterPlugin, MethodCallHandler {
                     for (flutterSerializedModel in flutterSerializedModels) {
                         val nestedSerializedModel = flutterSerializedModel.serializedModel.serializedData[associationKey] as SerializedModel
                         val modelId = nestedSerializedModel.serializedData["id"].toString();
-                        if (nestedModelHashMap.isNotEmpty()) {
-                            val nestedModel = nestedModelHashMap[modelId]
-                            if (nestedModel != null) {
-                                val nestedFlutterSerializedModel = FlutterSerializedModel(nestedModel as SerializedModel)
-                                nestedFlutterSerializedModels.add(nestedFlutterSerializedModel)
-                                flutterSerializedModel.associations[associationKey] = nestedFlutterSerializedModel
-                            } else {
-                                // TODO: How to handle when the data is not found in the DB
-                                LOG.error("Nested model $nestedModelName with ID $modelId was not in DB")
-                            }
+                        val nestedModel = nestedModelHashMap[modelId]
+                        if (nestedModel != null) {
+                            val nestedFlutterSerializedModel = FlutterSerializedModel(nestedModel as SerializedModel)
+                            nestedFlutterSerializedModels.add(nestedFlutterSerializedModel)
+                            flutterSerializedModel.associations[associationKey] = nestedFlutterSerializedModel
                         } else {
-                            // TODO: How to handle when the data is not found in the DB
-                            LOG.error("Empty nestedModelList.")
+                            // TODO: How to handle when the data is not found in the local DB (data not synced)
+                            LOG.error("Nested model $nestedModelName with ID $modelId was not in DB")
                         }
                     }
                     // query nested models, then query the remaining associations of the current set of models

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/model/FlutterSerializedModel.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/model/FlutterSerializedModel.kt
@@ -16,12 +16,16 @@
 package com.amazonaws.amplify.amplify_datastore.types.model
 
 import com.amplifyframework.core.model.Model
+import com.amplifyframework.core.model.ModelAssociation
+import com.amplifyframework.core.model.ModelSchema
 import com.amplifyframework.core.model.temporal.Temporal
 import com.amplifyframework.datastore.appsync.SerializedModel
 import java.lang.Exception
 
 
 data class FlutterSerializedModel(val serializedModel: SerializedModel) {
+
+    val associations: MutableMap<String, FlutterSerializedModel> = HashMap<String, FlutterSerializedModel>();
 
     private val serializedData: Map<String, Any> = parseSerializedDataMap(serializedModel.serializedData)
 
@@ -32,7 +36,7 @@ data class FlutterSerializedModel(val serializedModel: SerializedModel) {
     fun toMap(): Map<String, Any> {
         return mapOf(
                 "id" to id,
-                "serializedData" to serializedData,
+                "serializedData" to serializedData.plus(associations.mapValues { it.value.serializedData }),
                 "modelName" to modelName)
     }
 

--- a/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/model/FlutterSerializedModel.kt
+++ b/packages/amplify_datastore/android/src/main/kotlin/com/amazonaws/amplify/amplify_datastore/types/model/FlutterSerializedModel.kt
@@ -25,7 +25,7 @@ import java.lang.Exception
 
 data class FlutterSerializedModel(val serializedModel: SerializedModel) {
 
-    val associations: MutableMap<String, FlutterSerializedModel> = HashMap<String, FlutterSerializedModel>();
+    val associations: MutableMap<String, FlutterSerializedModel> = HashMap();
 
     // ignored fields
     private val id: String = serializedModel.id
@@ -58,6 +58,6 @@ data class FlutterSerializedModel(val serializedModel: SerializedModel) {
                 // It seems we can ignore collection types for now as we aren't returning lists of Models in hasMany relationships
                 else -> value
             }
-        }.plus(associations.mapValues { it.value.parseSerializedDataMap() })
+        }.plus(associations.mapValues { it.value.toMap() })
     }
 }


### PR DESCRIPTION
### Changes:
- Update datastore to return nested data for Android

### Performance implications
These changes result in multiple queries for nested models. The number of queries made is equal to 1 + M * B, where M = the number of nested model types to query and B = the page size (or query size) / 1,000. Note: 1,000 comes from the SQLite limit of how many conditions can be combined in a single query.

This means that an app that has the sample Blog -> Post -> Comment data model, fetching 1,000 comments will result in 3 queries (1 + 2 * 1,000/1,000) and fetching 10,000 comments would result in a worst case 21 queries.

The following sample data was collected from an Android emulator. Query times will vary by device. This is meant to indicate how the solution scales, not represent exact numbers that will be seen by end users.

- 1,000 records (B=1)
  - fetching all blogs (M=0): ~100ms (1 query)
  - fetching all posts (M=1): 300ms - 400ms (2 queries)
  - fetching all comments (M=2): 500ms - 700ms (3 queries)
- 10,000 records (B=10)
  - fetching all blogs (M=0): 700ms - 900ms (1 query)
  - fetching all posts (M=1): 2,600ms - 3,600ms, (11 queries)
  - fetching all comments (M=2): 5,500ms - 6,500ms (21 queries)

